### PR TITLE
Update WebArena openai syntax

### DIFF
--- a/brawl/gym/env/webarena_env/webarena/requirements.txt
+++ b/brawl/gym/env/webarena_env/webarena/requirements.txt
@@ -2,7 +2,7 @@ gymnasium
 playwright==1.32.1
 Pillow
 evaluate
-openai==0.27.0
+openai==1.86.0
 types-tqdm
 tiktoken
 aiolimiter

--- a/brawl/gym/env/webarena_env/webarena/run.py
+++ b/brawl/gym/env/webarena_env/webarena/run.py
@@ -10,7 +10,7 @@ import tempfile
 import time
 from pathlib import Path
 
-import openai
+from openai import OpenAIError
 
 from agent import (
     Agent,
@@ -347,7 +347,7 @@ def test(
                     Path(args.result_dir) / "traces" / f"{task_id}.zip"
                 )
 
-        except openai.error.OpenAIError as e:
+        except OpenAIError as e:
             logger.info(f"[OpenAI Error] {repr(e)}")
         except Exception as e:
             logger.info(f"[Unhandled Error] {repr(e)}]")


### PR DESCRIPTION
## Summary
- update OpenAI dependency to v1.86.0
- adapt WebArena `openai_utils` helpers to use new `OpenAI` clients
- handle `OpenAIError` in run script

## Testing
- `python -m py_compile brawl/gym/env/webarena_env/webarena/llms/providers/openai_utils.py brawl/gym/env/webarena_env/webarena/run.py`
- `python -m py_compile brawl/gym/env/webarena_env/webarena/run.py`


------
https://chatgpt.com/codex/tasks/task_e_68534250c4848333816f74c9d8dd9ec5